### PR TITLE
Replace MIT License with Creative Commons Attribution 4.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,25 +8,7 @@ This is an Obsidian-based personal knowledge management system template called "
 
 ## Project Structure
 
-The repository follows a specific folder hierarchy for knowledge organization:
-- `Atomic Notes/` - Individual concept notes following Zettelkasten principles
-- `Structure Notes/` - Index/Map of Content (MOC) notes that connect related concepts
-- `Reference Notes/` - Notes from books, articles, and other external sources
-- `Vocabulary Notes/` - Definitions and explanations of terms
-- `People/` - Notes about individuals you interact with or study
-- `Places and Things/` - Notes about locations, objects, and tools
-- `Projects/` - Project documentation and planning
-- `Meetings/` - Meeting notes and records
-- `Jobs/` - Job opportunities and career-related information
-- `Reviews/` - Periodic reviews and reflections
-  - `Daily Notes/` - Daily journals and reflections
-  - `Weekly Review/` - Weekly summaries and planning
-  - `Quarterly Reviews/` - Quarterly assessments and goal setting
-  - `Decisions/` - Decision logs and analysis
-  - `Interviews/` - Interview notes and feedback
-- `Inbox/` - Temporary storage for unprocessed notes
-- `Attachments/` - Media files and attachments
-- `Templates/` - Reusable templates for different note types
+The repository follows a specific folder hierarchy for knowledge organization. See `README.md` for the complete folder structure and descriptions.
 
 ## Key Configuration
 
@@ -37,15 +19,12 @@ The repository follows a specific folder hierarchy for knowledge organization:
 - `workspace.json` defines the workspace layout
 
 ### Active Plugins
-- Natural Language Dates - Parse natural language dates
-- Periodic Notes - Daily/weekly note creation
-- Calendar - Visual calendar interface
-- Dataview - Query and display data from notes
-- Linter - Markdown formatting and consistency
-- Tag Wrangler - Tag management
-- Outliner - Enhanced outline functionality
+See `README.md` for the list of configured plugins and their descriptions.
 
 ## Development Guidelines
+
+### Single Source of Truth
+Maintain a single source of truth for all documentation. Avoid duplicating information across multiple files. Instead, reference the authoritative source. For example, the folder structure and plugin list are maintained in `README.md` and should be referenced from other documentation rather than duplicated.
 
 ### Working with Templates
 Templates are markdown files in the `Templates/` folder that define the structure for new notes. When modifying templates:

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,23 +1,52 @@
-# MIT License
+---
+aliases: []
+date_created: 2025-07-12 19:07
+date_modified: 2025-07-12 19:07
+tags: []
+title: Creative Commons Attribution 4.0 International License (CC BY 4.0)
+---
 
-MIT License
+# Creative Commons Attribution 4.0 International License (CC BY 4.0)
 
-Copyright (c) 2025 Jason Gilbertson
+## Attribution
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Copyright (c) 2025 Jason Gilbertson and Terri Yeh.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+This work is licensed under the Creative Commons Attribution 4.0 International License.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+## License Summary
+
+You are free to:
+
+- **Share**—copy and redistribute the material in any medium or format
+- **Adapt**—remix, transform, and build upon the material for any purpose, even commercially
+
+Under the following terms:
+
+- **Attribution**—You must give appropriate credit, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.
+
+## Full License Text
+
+To view a copy of this license, visit:
+
+https://creativecommons.org/licenses/by/4.0/
+
+Or send a letter to:
+
+Creative Commons
+PO Box 1866
+Mountain View, CA 94042, USA
+
+## Attribution Guidelines
+
+When attributing this work, please include:
+
+1. The title: "Curate, Cultivate, Connect Knowledge System"
+2. The author: Jason Gilbertson and Terri Yeh
+3. The source: https://github.com/jrgilbertson/curate-connect-cultivate-knowledge-system
+4. The license: CC BY 4.0
+5. Any changes made to the original work
+
+Example attribution:
+
+"Curate, Cultivate, Connect Knowledge System" by Jason Gilbertson and Terri Yeh, licensed under CC BY 4.0. Original source: https://github.com/jrgilbertson/curate-connect-cultivate-knowledge-system. [Describe any changes if applicable.]

--- a/README.md
+++ b/README.md
@@ -14,28 +14,32 @@ _Note: This repository is undergoing a significant overhaul as the author has co
 
 This is an Obsidian-based personal knowledge management system template that provides a structured approach to organizing notes, knowledge, and information using the Curate, Connect, Cultivate methodology.
 
+## Curate, Cultivate, Connect Methodology
+
+TBD.
+
 ## Folder Structure
 
 The vault is organized into the following directories:
 
+- **Attachments/** - Media files and attachments
 - **Atomic Notes/** - Individual concept notes following Zettelkasten principles
-- **Structure Notes/** - Index/Map of Content (MOC) notes that connect related concepts
-- **Reference Notes/** - Notes from books, articles, and other external sources
-- **Vocabulary Notes/** - Definitions and explanations of terms
+- **Inbox/** - Temporary storage for unprocessed notes
+- **Jobs/** - Job opportunities and career-related information
+- **Meetings/** - Meeting notes and records
 - **People/** - Notes about individuals you interact with or study
 - **Places and Things/** - Notes about locations, objects, and tools
 - **Projects/** - Project documentation and planning
-- **Meetings/** - Meeting notes and records
-- **Jobs/** - Job opportunities and career-related information
+- **Reference Notes/** - Notes from books, articles, and other external sources
 - **Reviews/** - Periodic reviews and reflections
   - **Daily Notes/** - Daily journals and reflections
-  - **Weekly Review/** - Weekly summaries and planning
-  - **Quarterly Reviews/** - Quarterly assessments and goal setting
   - **Decisions/** - Decision logs and analysis
   - **Interviews/** - Interview notes and feedback
-- **Inbox/** - Temporary storage for unprocessed notes
-- **Attachments/** - Media files and attachments
+  - **Quarterly Reviews/** - Quarterly assessments and goal setting
+  - **Weekly Review/** - Weekly summaries and planning
+- **Structure Notes/** - Index note that connect related concepts
 - **Templates/** - Reusable templates for different note types
+- **Vocabulary Notes/** - Definitions and explanations of terms
 
 ## Getting Started
 
@@ -48,6 +52,7 @@ The vault is organized into the following directories:
 ## Templates
 
 The system includes templates for:
+
 - Atomic notes (with and without Anki integration)
 - Daily notes
 - Weekly and quarterly reviews
@@ -61,6 +66,7 @@ The system includes templates for:
 ## Plugins
 
 This vault comes configured with several helpful plugins:
+
 - Calendar - Visual calendar interface
 - Dataview - Query and display data from notes
 - Natural Language Dates - Parse natural language dates
@@ -72,3 +78,7 @@ This vault comes configured with several helpful plugins:
 ## Contributing
 
 This system is continuously evolving. If you have suggestions or improvements, please feel free to open an issue or submit a pull request.
+
+## License
+
+This work is licensed under the [Creative Commons Attribution 4.0 International License (CC BY 4.0)](LICENSE.md).


### PR DESCRIPTION
## Summary
- Replaced MIT License with Creative Commons Attribution 4.0 International (CC BY 4.0)
- Added co-author Terri Yeh to copyright notice
- Updated documentation to implement single source of truth principle

## Changes
1. **LICENSE.md**: 
   - Changed from MIT to CC BY 4.0
   - Added both authors (Jason Gilbertson and Terri Yeh)
   - Included repository URL in attribution guidelines
   
2. **CLAUDE.md**:
   - Added single source of truth development guideline
   - Removed duplicated folder structure (now references README.md)
   - Removed duplicated plugin list (now references README.md)
   
3. **README.md**:
   - Added License section referencing CC BY 4.0

## Rationale
Creative Commons licenses are more appropriate for book content and creative works, while still maintaining open source principles with required attribution.

## Test plan
- [x] Verify LICENSE.md contains correct CC BY 4.0 text
- [x] Confirm both authors are listed in copyright
- [x] Check that repository URL is included in attribution examples
- [x] Verify CLAUDE.md references README.md for shared information
- [x] Confirm README.md has license section

🤖 Generated with [Claude Code](https://claude.ai/code)